### PR TITLE
prodのotelcol-config

### DIFF
--- a/otelcol-config/README.md
+++ b/otelcol-config/README.md
@@ -8,6 +8,14 @@
 - `make generate-code` で collector のコードを生成する
 - git commit し、pull request を作る
 
+# install の仕方 (初回のみ)
+
+- AMD64 版の otelcol を install する
+  - [Install the Collector | OpenTelemetry#DEB Installation](https://opentelemetry.io/docs/collector/installation/#deb-installation])
+- Mackerel の API key を設定する
+  - `/etc/otelcol/otelcol.conf` に `MACKEREL_APIKEY="〜"` を追記する
+- 以下、otelcol を deploy する
+
 # deploy の仕方
 
 - (otelcol をインストールしていなければ) dpkg で otelcol を入れる

--- a/prod/otelcol/otelcol-o11y-stack-config.yaml
+++ b/prod/otelcol/otelcol-o11y-stack-config.yaml
@@ -19,25 +19,37 @@ receivers:
       memory:
       network:
       paging:
-  filelog:
-    include:
-      - /var/lib/docker/containers/*/*-json.log
-    encoding: utf-8
-    include_file_name: false
-    include_file_path: true
-    operators:
-      - id: container-parser
-        type: container
+  prometheus/grafana:
+    config:
+      scrape_configs:
+        - job_name: grafana
+          scrape_interval: 1m
+          static_configs:
+            - targets: ['localhost:3000']
 
 processors:
   attributes:
     actions:
       - action: upsert
         key: service.namespace
-        value: sentry-stg
+        value: o11y-stacks
       - action: upsert
         key: service.name
-        value: sentry-stg
+        value: o11y-stacks
+      - action: upsert
+        key: deployment.environment.name
+        value: prod
+  attributes/grafana:
+    actions:
+      - action: upsert
+        key: service.namespace
+        value: o11y-stacks
+      - action: upsert
+        key: service.name
+        value: grafana
+      - action: upsert
+        key: deployment.environment.name
+        value: prod
   batch:
     timeout: 1m
   resourcedetection/system:
@@ -51,21 +63,15 @@ exporters:
     compression: gzip
     headers:
       Mackerel-Api-Key: ${env:MACKEREL_APIKEY}
-  otlphttp/loki:
-    endpoint: https://stg.loki.cloudnativedays.jp/otlp
 
 service:
   pipelines:
-    # traces:
-    #   receivers: [otlp]
-    #   processors: [batch]
-    #   exporters: [debug]
     metrics:
       receivers: [otlp, hostmetrics]
       processors: [attributes, batch, resourcedetection/system]
       exporters: [otlp/mackerel]
-    logs:
-      receivers: [filelog]
-      processors: [batch]
-      exporters: [otlphttp/loki]
+    metrics/grafana:
+      receivers: [prometheus/grafana]
+      processors: [attributes/grafana, batch]
+      exporters: [otlp/mackerel]
   extensions: [health_check]

--- a/stg/otelcol-config/otelcol-o11y-stack-config.yaml
+++ b/stg/otelcol-config/otelcol-o11y-stack-config.yaml
@@ -32,18 +32,24 @@ processors:
     actions:
       - action: upsert
         key: service.namespace
-        value: o11y-stacks-stg
+        value: o11y-stacks
       - action: upsert
         key: service.name
-        value: o11y-stacks-stg
+        value: o11y-stacks
+      - action: upsert
+        key: deployment.environment.name
+        value: stg
   attributes/grafana:
     actions:
       - action: upsert
         key: service.namespace
-        value: o11y-stacks-stg
+        value: o11y-stacks
       - action: upsert
         key: service.name
         value: grafana
+      - action: upsert
+        key: deployment.environment.name
+        value: stg
   batch:
     timeout: 1m
   resourcedetection/system:
@@ -60,10 +66,6 @@ exporters:
 
 service:
   pipelines:
-    # traces:
-    #   receivers: [otlp]
-    #   processors: [batch]
-    #   exporters: [debug]
     metrics:
       receivers: [otlp, hostmetrics]
       processors: [attributes, batch, resourcedetection/system]
@@ -72,8 +74,4 @@ service:
       receivers: [prometheus/grafana]
       processors: [attributes/grafana, batch]
       exporters: [otlp/mackerel]
-    # logs:
-    #   receivers: [otlp]
-    #   processors: [batch]
-    #   exporters: [debug]
   extensions: [health_check]


### PR DESCRIPTION
- Sentryをself-hostedからcloud版に移行したのに伴い、Sentry向けのconfigを消した。
- prodのo11y-<del>s</del>stack向けのconfigを書いた。
- 環境を `deployment.environment.name` 属性で区別するよう変えた
  - [Deployment | OpenTelemetry](https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/)