### PR TITLE
chore: Grafana 13.0.1 のメモリリーク対策として gzip 圧縮を無効化

### DIFF
--- a/prod/grafana/grafana.ini
+++ b/prod/grafana/grafana.ini
@@ -1,5 +1,6 @@
 [server]
     root_url = https://grafana.cloudnativedays.jp
+    enable_gzip = false
 [auth]
     disable_login_form = true
     oauth_auto_login = true

--- a/stg/grafana/grafana.ini
+++ b/stg/grafana/grafana.ini
@@ -1,5 +1,6 @@
 [server]
     root_url = https://stg.grafana.cloudnativedays.jp
+    enable_gzip = false
 [auth]
     disable_login_form = true
     oauth_auto_login = true


### PR DESCRIPTION
## Summary

Grafana 13.0.1 へのアップデート後、コンテナが頻繁に再起動する問題への対応。

原因は Grafana 13.0.1 で gzip 圧縮ライブラリが `compress/gzip` から `klauspost/pgzip` に変更されたことによるメモリ使用量の大幅増加（メモリリーク）。

stg / prod 両環境の `grafana.ini` に `enable_gzip = false` を設定し、OOM によるコンテナ再起動を防止する。

## Related Issues

- https://github.com/grafana/grafana/issues/123017
- https://github.com/grafana/grafana/issues/123571

## Changes

- `stg/grafana/grafana.ini`: `[server]` セクションに `enable_gzip = false` を追加
- `prod/grafana/grafana.ini`: `[server]` セクションに `enable_gzip = false` を追加

## Notes

- Grafana 側で圧縮ライブラリを `klauspost/compress` に置き換える PR ([grafana/grafana#118424](https://github.com/grafana/grafana/pull/118424)) が進行中
- 上記 PR がマージされたバージョンにアップデート後、`enable_gzip = true` に戻すことを検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)